### PR TITLE
Added two missing functionalities: always & hanging getValue

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="" vcs="Git" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ Promise.resolve (5)
        ._catch (Promise.ignoreReason);
 ```
 
-In the example above, we must point our several things. First, execution continues
+In the example above, we must point out several things. Firstly, execution continues
 after the first `_catch` if any of the preceding promises is rejected. If none of
-the promises are rejected, then the first `_catch` is skipped. Second, we are using
+the promises are rejected, then the first `_catch` is skipped. Secondly, we are using
 Java method references (i.e., `this::doSomethingElse`), which improves the readability
 of the code, and reduces verbosity. Lastly, `Promise.ignoreReason` is a special 
 handler that will catch the rejection and ignore the reason. This way, you do not have

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 build.group=com.github.onehilltech
-build.version=0.7.0
+build.version=0.7.1
 build.versionCode=7

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 build.group=com.github.onehilltech
-build.version=0.6.0
-build.versionCode=6
+build.version=0.7.0
+build.versionCode=7

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 build.group=com.github.onehilltech
-build.version=0.7.1
+build.version=0.7.2
 build.versionCode=7

--- a/promises-jvm/build.gradle
+++ b/promises-jvm/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'maven'
 
 group = project.property('build.group')
 
-targetCompatibility = '1.8'
-sourceCompatibility = '1.8'
+targetCompatibility = '1.7'
+sourceCompatibility = '1.7'
 
 // In this section you declare the dependencies for your production and test code
 dependencies {

--- a/promises-jvm/build.gradle
+++ b/promises-jvm/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'maven'
 
 group = project.property('build.group')
 
-targetCompatibility = '1.7'
-sourceCompatibility = '1.7'
+targetCompatibility = '1.8'
+sourceCompatibility = '1.8'
 
 // In this section you declare the dependencies for your production and test code
 dependencies {

--- a/promises-jvm/src/main/java/com/onehilltech/promises/OnAlways.java
+++ b/promises-jvm/src/main/java/com/onehilltech/promises/OnAlways.java
@@ -1,0 +1,11 @@
+package com.onehilltech.promises;
+
+public interface OnAlways <U>
+{
+    /**
+     * Callback handler that is called when a promise is resolved or rejected.
+     *
+     * @return Optional promise
+     */
+    void OnAlways ();
+}

--- a/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
+++ b/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
@@ -345,6 +345,19 @@ public class Promise<T> {
         return this.then(OnResolvedExecutor.wrapOrNull(onResolved), OnRejectedExecutor.wrapOrNull(onRejected));
     }
 
+    public <U> Promise<U> always(OnAlways<U> onAlways) {
+        return this.then((OnResolvedExecutor<T, U>) OnResolvedExecutor.wrapOrNull(
+                (v) -> {
+                    onAlways.OnAlways();
+                    return Promise.resolve(v);
+                }),
+                OnRejectedExecutor.wrapOrNull((e) -> {
+                    onAlways.OnAlways();
+                    return Promise.reject(e);
+                })
+        );
+    }
+
     /**
      * Add an error handler to the chain.
      *

--- a/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
+++ b/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
@@ -255,6 +255,12 @@ public class Promise<T> {
         return this.getStatus() == Status.Rejected;
     }
 
+    /**
+     * Gets the current value of the promise. Waits if the promise is still pending.
+     * Important this method will hang.
+     * @throws Throwable when the promise is rejected.
+     * @return
+     */
     public T getValue() throws Throwable {
         while (isPending()) {
             try {
@@ -345,6 +351,13 @@ public class Promise<T> {
         return this.then(OnResolvedExecutor.wrapOrNull(onResolved), OnRejectedExecutor.wrapOrNull(onRejected));
     }
 
+    /**
+     * Always will always run whether the promise is resolved or rejected.
+     *
+     * @param onAlways
+     * @param <U>
+     * @return
+     */
     public <U> Promise<U> always(final OnAlways<U> onAlways) {
         return this.then(
                 new OnResolved() {

--- a/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
+++ b/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
@@ -30,735 +30,651 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
+ * @param <T>
  * @class Promise
- *
+ * <p>
  * A promise is an object which can be returned synchronously from an asynchronous
  * function.
- *
- * @param <T>
  */
-public class Promise <T>
-{
-  /**
-   * @interface Settlement
-   *
-   * Settlement interface used to either resolve or reject a promise.
-   *
-   * @param <T>
-   */
-  public interface Settlement <T>
-  {
-    void resolve (T value);
+public class Promise<T> {
+    /**
+     * @param <T>
+     * @interface Settlement
+     * <p>
+     * Settlement interface used to either resolve or reject a promise.
+     */
+    public interface Settlement<T> {
+        void resolve(T value);
 
-    void reject (Throwable reason);
-  }
-
-  public interface OnRejected
-  {
-    Promise onRejected (Throwable reason);
-  }
-
-  public static <T, U> OnResolved <T, U> resolved (ResolveNoReturn <T> resolveNoReturn)
-  {
-    return new OnResolvedNoReturn<> (resolveNoReturn);
-  }
-
-  /**
-   * Factory method that creates an OnRejected handler that does not return a Promise
-   * value to be used in the chain.
-   *
-   * @param rejectNoReturn        RejectNoReturn instance
-   * @return
-   */
-  public static OnRejected rejected (RejectNoReturn rejectNoReturn)
-  {
-    return new OnRejectedNoReturn (rejectNoReturn);
-  }
-
-  /**
-   * Helper OnRejected handler for ignoring the reason a Promise is execute.
-   */
-  public static final OnRejected ignoreReason = rejected (new RejectNoReturn ()
-  {
-    @Override
-    public void rejectNoReturn (Throwable reason)
-    {
-
-    }
-  });
-
-  public enum Status
-  {
-    /// The promise is in a pending state.
-    Pending,
-
-    /// The promise has been execute.
-    Resolved,
-
-    /// The promise has been execute.
-    Rejected,
-
-    /// The promise has been cancelled.
-    Cancelled
-  }
-
-  /// The execute value for the promise.
-  private T value_;
-
-  /// Current status for the promise.
-  private Status status_;
-
-  /// Future for the promise execution.
-  private Future<?> future_;
-
-  /// The execute value for the promise.
-  private Throwable rejection_;
-
-  private final ReentrantReadWriteLock stateLock_ = new ReentrantReadWriteLock ();
-
-  private static class PromiseThreadFactory implements ThreadFactory
-  {
-    private AtomicInteger counter_ = new AtomicInteger (0);
-
-    @Override
-    public Thread newThread (Runnable runnable)
-    {
-      String threadName = "PromiseThread-" + this.counter_.getAndIncrement ();
-      return new Thread (runnable, threadName);
-    }
-  }
-
-  private static final ExecutorService DEFAULT_EXECUTOR = Executors.newCachedThreadPool (new PromiseThreadFactory ());
-
-  private final PromiseExecutor<T> impl_;
-
-  private final ExecutorService executor_;
-
-  private final String name_;
-
-  /**
-   * Link to a continuation promise that is waiting for its parent promise
-   * to reach a settlement.
-   */
-  private static class PendingEntry <T>
-  {
-    /// Next promise in the chain.
-    final ContinuationPromise <?> cont;
-
-    /// Handler for when the promise is execute.
-    final OnResolvedExecutor<T, ?> onResolved;
-
-    /// Handler for when the promise is execute.
-    final OnRejectedExecutor onRejected;
-
-    PendingEntry (ContinuationPromise <?> cont, OnResolvedExecutor <T, ?> onResolved, OnRejectedExecutor onRejected)
-    {
-      this.cont = cont;
-      this.onResolved = onResolved;
-      this.onRejected = onRejected;
+        void reject(Throwable reason);
     }
 
-    void resolved (Executor executor, T value)
-    {
-      if (this.onResolved != null)
-        this.onResolved.execute (executor, value, this.cont);
+    public interface OnRejected {
+        Promise onRejected(Throwable reason);
     }
 
-    void rejected (Executor executor, Throwable reason)
-    {
-      if (this.onRejected != null)
-        this.onRejected.execute (executor, reason, this.cont);
+    public static <T, U> OnResolved<T, U> resolved(ResolveNoReturn<T> resolveNoReturn) {
+        return new OnResolvedNoReturn<>(resolveNoReturn);
     }
-  }
 
-  private final ArrayList <PendingEntry <T>> pendingEntries_ = new ArrayList<> ();
-
-  /**
-   * The executor for the Promise.
-   *
-   * @param impl        Executor that settles the promise.
-   */
-  public Promise (PromiseExecutor<T> impl)
-  {
-    this (null, impl);
-  }
-
-  /**
-   * The executor for the promise.
-   *
-   * @param name        Name of the promise
-   * @param impl        Executor that settles the promise.
-   */
-  public Promise (String name, PromiseExecutor<T> impl)
-  {
-    this (name, impl, Status.Pending, null, null);
-  }
-
-  /**
-   * Create a Promise that is execute.
-   *
-   * @param resolve
-   */
-  private Promise (T resolve)
-  {
-    this (null, null, Status.Resolved, resolve, null);
-  }
-
-  /**
-   * Create a Promise that is execute.
-   *
-   * @param reason
-   */
-  private Promise (Throwable reason)
-  {
-    this (null, null, Status.Rejected, null, reason);
-  }
-
-  /**
-   * Initializing constructor.
-   *
-   * @param name            Name of the promise
-   * @param impl            Promise executor implementation
-   * @param resolve         Resolved value
-   * @param reason          Rejected value
-   */
-  private Promise (String name, PromiseExecutor<T> impl, Status status, T resolve, Throwable reason)
-  {
-    this.name_ = name;
-    this.impl_ = impl;
-    this.value_ = resolve;
-    this.rejection_ = reason;
-    this.status_ = status;
-    this.executor_ = DEFAULT_EXECUTOR;
-
-    // If the promise is not pending, then we need to continueWith the promise. We also
-    // need to continueWith the promise in the background so normal control can continue.
-    if (this.status_ == Status.Pending && this.impl_ != null)
-      this.settlePromise ();
-  }
-
-  /**
-   * Get the name of the promise.
-   *
-   * @return        Name of promise
-   */
-  public String getName ()
-  {
-    return this.name_;
-  }
-
-  /**
-   * Get the status of the promise.
-   *
-   * @return          Status enumeration
-   */
-  public Status getStatus ()
-  {
-    try
-    {
-      this.stateLock_.readLock ().lock ();
-      return this.status_;
+    /**
+     * Factory method that creates an OnRejected handler that does not return a Promise
+     * value to be used in the chain.
+     *
+     * @param rejectNoReturn RejectNoReturn instance
+     * @return
+     */
+    public static OnRejected rejected(RejectNoReturn rejectNoReturn) {
+        return new OnRejectedNoReturn(rejectNoReturn);
     }
-    finally
-    {
-      this.stateLock_.readLock ().unlock ();
-    }
-  }
 
-  public boolean isCancelled ()
-  {
-    return this.getStatus () == Status.Cancelled;
-  }
-
-  public boolean isPending ()
-  {
-    return this.getStatus () == Status.Pending;
-  }
-
-  public boolean isResolved ()
-  {
-    return this.getStatus () == Status.Resolved;
-  }
-
-  public boolean isRejected ()
-  {
-    return this.getStatus () == Status.Rejected;
-  }
-
-  /**
-   * Cancel the promise.
-   *
-   * @return        True if cancelled, otherwise false.
-   */
-  public boolean cancel ()
-  {
-    return this.cancel (true);
-  }
-
-  /**
-   * Cancel the promise
-   *
-   * @param mayInterruptIfRunning         Interrupt promise is running
-   * @return                              True if cancelled; otherwise false
-   */
-  public boolean cancel (boolean mayInterruptIfRunning)
-  {
-    if (this.status_ != Status.Pending)
-      return false;
-
-    try
-    {
-      this.stateLock_.writeLock ().lock ();
-
-      if (this.status_ != Status.Pending)
-        return false;
-
-      boolean result = this.future_.cancel (mayInterruptIfRunning);
-
-      if (result)
-        this.status_ = Status.Cancelled;
-
-      return result;
-    }
-    finally
-    {
-      this.stateLock_.writeLock ().unlock ();
-    }
-  }
-
-  /**
-   * Add a chain to the promise.
-   *
-   * @param onResolved
-   * @param <U>
-   * @return
-   */
-  public <U> Promise <U> then (OnResolved <T, U> onResolved)
-  {
-    if (onResolved == null)
-      throw new IllegalStateException ("The resolve handler cannot be null");
-
-    return this.then (onResolved, null);
-  }
-
-  /**
-   * Add a chain to the promise.
-   *
-   * @param onResolved
-   * @param <U>
-   * @return
-   */
-  public <U> Promise <U> then (OnResolvedExecutor <T, U> onResolved)
-  {
-    if (onResolved == null)
-      throw new IllegalStateException ("The resolve handler cannot be null");
-
-    return this.then (onResolved, null);
-  }
-
-  /**
-   * Add a chain to the promise.
-   *
-   * @param onResolved
-   * @param onRejected
-   * @param <U>
-   * @return
-   */
-  public <U> Promise <U> then (OnResolved <T, U> onResolved, OnRejected onRejected)
-  {
-    return this.then (OnResolvedExecutor.wrapOrNull (onResolved), OnRejectedExecutor.wrapOrNull (onRejected));
-  }
-
-  /**
-   * Add an error handler to the chain.
-   *
-   * @param onRejected
-   * @param <U>
-   * @return
-   */
-  public <U> Promise <U> _catch (OnRejected onRejected)
-  {
-    if (onRejected == null)
-      throw new IllegalStateException ("The rejected handler cannot be null.");
-
-    return this.then (null, onRejected);
-  }
-
-  /**
-   * Add an error handler to the chain.
-   *
-   * @param onRejected
-   * @param <U>
-   * @return
-   */
-  public <U> Promise <U> _catch (OnRejectedExecutor onRejected)
-  {
-    if (onRejected == null)
-      throw new IllegalStateException ("The rejected handler cannot be null.");
-
-    return this.then (null, onRejected);
-  }
-
-  /**
-   * Settle the promise. The promised will either be execute or execute.
-   *
-   * @param onResolved          Handler called when execute.
-   * @param onRejected          Handler called when execute.
-   */
-  @SuppressWarnings ("unchecked")
-  public <U> Promise <U> then (OnResolvedExecutor <T, U> onResolved, OnRejectedExecutor onRejected)
-  {
-    final ContinuationPromise continuation = new ContinuationPromise<> ();
-
-    try
-    {
-      // Get the read lock so that t
-      this.stateLock_.readLock ().lock ();
-
-      if (this.status_ == Status.Resolved)
-      {
-        // The promise is already execute. If the client has provided a handler,
-        // then we need to invoke it and determine how we are to proceed. Otherwise,
-        // we need to continue down the chain with a new start (i.e., a null value).
-        if (onResolved != null)
-          onResolved.execute (this.executor_, this.value_, continuation);
-        else
-          continuation.continueWithNull ();
-      }
-      else if (this.status_ == Status.Rejected)
-      {
-        // We are handling the rejection as this level. Either we are going to handle
-        // the rejection as this level via a onRejected handler, or we are going to
-        // pass the rejection to the next level.
-        if (onRejected != null)
-          onRejected.execute (this.executor_, this.rejection_, continuation);
-        else
-          continuation.continueWith (this.rejection_);
-      }
-      else if (this.status_ == Status.Pending)
-      {
-        // The promise is still pending. We need to add the execute and execute
-        // handlers to the waiting list along with the continuation promise returned
-        // from this call. This ensure the promise from the resolve/execute handlers
-        // is passed to the correct continuation promise.
-        this.pendingEntries_.add (new PendingEntry<> (continuation, onResolved, onRejected));
-      }
-
-      return continuation;
-    }
-    finally
-    {
-      this.stateLock_.readLock ().unlock ();
-    }
-  }
-
-  /**
-   * Settle the promise.
-   */
-  private void settlePromise ()
-  {
-    this.future_ = this.executor_.submit (new Runnable ()
-    {
-      @Override
-      public void run ()
-      {
-        settlePromiseImpl ();
-      }
-    });
-  }
-
-  /**
-   * The actual implementation for settling a promise.
-   */
-  private void settlePromiseImpl ()
-  {
-    try
-    {
-      // Execute the promise. This method must call either resolve or reject
-      // before this method return. Failure to do so means the promise was not
-      // completed, and in a bad state.
-      this.impl_.execute (new Settlement<T> ()
-      {
+    /**
+     * Helper OnRejected handler for ignoring the reason a Promise is execute.
+     */
+    public static final OnRejected ignoreReason = rejected(new RejectNoReturn() {
         @Override
-        public void resolve (T value)
-        {
-          onResolve (value);
+        public void rejectNoReturn(Throwable reason) {
+
         }
+    });
+
+    public enum Status {
+        /// The promise is in a pending state.
+        Pending,
+
+        /// The promise has been execute.
+        Resolved,
+
+        /// The promise has been execute.
+        Rejected,
+
+        /// The promise has been cancelled.
+        Cancelled
+    }
+
+    /// The execute value for the promise.
+    private T value_;
+
+    /// Current status for the promise.
+    private Status status_;
+
+    /// Future for the promise execution.
+    private Future<?> future_;
+
+    /// The execute value for the promise.
+    private Throwable rejection_;
+
+    private final ReentrantReadWriteLock stateLock_ = new ReentrantReadWriteLock();
+
+    private static class PromiseThreadFactory implements ThreadFactory {
+        private AtomicInteger counter_ = new AtomicInteger(0);
 
         @Override
-        public void reject (Throwable reason)
-        {
-          onReject (reason);
+        public Thread newThread(Runnable runnable) {
+            String threadName = "PromiseThread-" + this.counter_.getAndIncrement();
+            return new Thread(runnable, threadName);
         }
-      });
-    }
-    catch (Exception e)
-    {
-      this.onReject (e);
-    }
-  }
-
-  @SuppressWarnings ("unchecked")
-  void onResolve (T value)
-  {
-    // Check that the promise is still pending. This is an implementation of the
-    // double-checked locking software design pattern.
-    if (this.status_ != Status.Pending)
-      throw new IllegalStateException ("Promise must be pending to resolve.");
-
-    try
-    {
-      // Get a write lock to the state since we are updating it. We do not want
-      // other threads reading the state until we are done.
-      this.stateLock_.writeLock ().lock ();
-
-      // Check that the promise is still pending.
-      if (this.status_ != Status.Pending)
-        throw new IllegalStateException ("Promise must be pending to resolve");
-
-      // Cache the result of the promise.
-      this.status_ = Status.Resolved;
-      this.value_ = value;
-    }
-    finally
-    {
-      this.stateLock_.writeLock ().unlock ();
     }
 
-    if (!this.pendingEntries_.isEmpty ())
-    {
-      // Let's each of pending entry know we have execute the promise. Afterwards,
-      // we need to clear the pending entry list.
+    private static final ExecutorService DEFAULT_EXECUTOR = Executors.newCachedThreadPool(new PromiseThreadFactory());
 
-      for (PendingEntry<T> entry : this.pendingEntries_)
-        entry.resolved (this.executor_, value);
+    private final PromiseExecutor<T> impl_;
 
-      // Clear the list of pending entries.
-      this.pendingEntries_.clear ();
-    }
-  }
+    private final ExecutorService executor_;
 
-  /**
-   * Bubble the rejection.
-   *
-   * @param reason
-   */
-  @SuppressWarnings ("unchecked")
-  void onReject (Throwable reason)
-  {
-    // Check that the promise is still pending. This is an implementation of the
-    // double-checked locking software design pattern.
-    if (this.status_ != Status.Pending)
-      throw new IllegalStateException ("Promise must be pending to resolve");
+    private final String name_;
 
-    try
-    {
-      // Get a write lock to the state since we are updating it. We do not want
-      // other threads reading the state until we are done.
-      this.stateLock_.writeLock ().lock ();
+    /**
+     * Link to a continuation promise that is waiting for its parent promise
+     * to reach a settlement.
+     */
+    private static class PendingEntry<T> {
+        /// Next promise in the chain.
+        final ContinuationPromise<?> cont;
 
-      // Check that the promise is still pending.
-      if (this.status_ != Status.Pending)
-        throw new IllegalStateException ("Promise must be pending to resolve");
+        /// Handler for when the promise is execute.
+        final OnResolvedExecutor<T, ?> onResolved;
 
-      this.rejection_ = reason;
-      this.status_ = Status.Rejected;
-    }
-    finally
-    {
-      this.stateLock_.writeLock ().unlock ();
+        /// Handler for when the promise is execute.
+        final OnRejectedExecutor onRejected;
+
+        PendingEntry(ContinuationPromise<?> cont, OnResolvedExecutor<T, ?> onResolved, OnRejectedExecutor onRejected) {
+            this.cont = cont;
+            this.onResolved = onResolved;
+            this.onRejected = onRejected;
+        }
+
+        void resolved(Executor executor, T value) {
+            if (this.onResolved != null)
+                this.onResolved.execute(executor, value, this.cont);
+        }
+
+        void rejected(Executor executor, Throwable reason) {
+            if (this.onRejected != null)
+                this.onRejected.execute(executor, reason, this.cont);
+        }
     }
 
-    if (!this.pendingEntries_.isEmpty ())
-    {
-      // Let's each of pending entry know we have execute the promise. Afterwards,
-      // we need to clear the pending entry list.
+    private final ArrayList<PendingEntry<T>> pendingEntries_ = new ArrayList<>();
 
-      for (PendingEntry<T> entry : this.pendingEntries_)
-        entry.rejected (this.executor_, reason);
-
-      // Clear the list of pending entries.
-      this.pendingEntries_.clear ();
+    /**
+     * The executor for the Promise.
+     *
+     * @param impl Executor that settles the promise.
+     */
+    public Promise(PromiseExecutor<T> impl) {
+        this(null, impl);
     }
-  }
 
-  /**
-   * Create a Promise that is already execute.
-   *
-   * @param value
-   * @param <T>
-   * @return
-   */
-  public static <T> Promise <T> resolve (T value)
-  {
-    return new Promise<> (value);
-  }
+    /**
+     * The executor for the promise.
+     *
+     * @param name Name of the promise
+     * @param impl Executor that settles the promise.
+     */
+    public Promise(String name, PromiseExecutor<T> impl) {
+        this(name, impl, Status.Pending, null, null);
+    }
 
-  /**
-   * Create a promise that is already execute.
-   *
-   * @param reason
-   * @return
-   */
-  public static <T> Promise <T> reject (Throwable reason)
-  {
-    return new Promise<> (reason);
-  }
+    /**
+     * Create a Promise that is execute.
+     *
+     * @param resolve
+     */
+    private Promise(T resolve) {
+        this(null, null, Status.Resolved, resolve, null);
+    }
 
-  /**
-   * Settle a collection of promises.
-   *
-   * @param promises
-   * @return
-   */
-  public static Promise <List <Object>> all (Promise <?>... promises)
-  {
-    return all (Arrays.asList (promises));
-  }
+    /**
+     * Create a Promise that is execute.
+     *
+     * @param reason
+     */
+    private Promise(Throwable reason) {
+        this(null, null, Status.Rejected, null, reason);
+    }
 
-  /**
-   * Settle a collection of promises.
-   *
-   * @param promises
-   * @return
-   */
-  public static Promise <List <Object>> all (final List <Promise <?>> promises)
-  {
-    if (promises.isEmpty ())
-      return Promise.resolve (Collections.emptyList ());
+    /**
+     * Initializing constructor.
+     *
+     * @param name    Name of the promise
+     * @param impl    Promise executor implementation
+     * @param resolve Resolved value
+     * @param reason  Rejected value
+     */
+    private Promise(String name, PromiseExecutor<T> impl, Status status, T resolve, Throwable reason) {
+        this.name_ = name;
+        this.impl_ = impl;
+        this.value_ = resolve;
+        this.rejection_ = reason;
+        this.status_ = status;
+        this.executor_ = DEFAULT_EXECUTOR;
 
-    return new Promise<> (new PromiseExecutor<List<Object>> ()
-    {
-      @Override
-      public void execute (final Settlement<List<Object>> settlement)
-      {
-        final ArrayList <Object> results = new ArrayList<> (promises.size ());
-        final Iterator<Promise<?>> iterator = promises.iterator ();
+        // If the promise is not pending, then we need to continueWith the promise. We also
+        // need to continueWith the promise in the background so normal control can continue.
+        if (this.status_ == Status.Pending && this.impl_ != null)
+            this.settlePromise();
+    }
 
-        // The first promise in the collection that is execute causes all promises
-        // to be execute.
-        final OnRejected onRejected = new OnRejected ()
-        {
-          @Override
-          public Promise onRejected (Throwable reason)
-          {
-            settlement.reject (reason);
-            return null;
-          }
-        };
+    /**
+     * Get the name of the promise.
+     *
+     * @return Name of promise
+     */
+    public String getName() {
+        return this.name_;
+    }
 
-        final OnResolved onResolved = new OnResolved ()
-        {
-          @SuppressWarnings ("unchecked")
-          @Override
-          public Promise onResolved (Object value)
-          {
-            // Add the execute value to the result set.
-            results.add (value);
+    /**
+     * Get the status of the promise.
+     *
+     * @return Status enumeration
+     */
+    public Status getStatus() {
+        try {
+            this.stateLock_.readLock().lock();
+            return this.status_;
+        } finally {
+            this.stateLock_.readLock().unlock();
+        }
+    }
 
-            if (iterator.hasNext ())
-            {
-              // We have more promises to resolve. So, let's move to the next one and
-              // attempt to resolve it.
-              Promise<?> promise = iterator.next ();
-              promise.then (this, onRejected);
+    public boolean isCancelled() {
+        return this.getStatus() == Status.Cancelled;
+    }
+
+    public boolean isPending() {
+        return this.getStatus() == Status.Pending;
+    }
+
+    public boolean isResolved() {
+        return this.getStatus() == Status.Resolved;
+    }
+
+    public boolean isRejected() {
+        return this.getStatus() == Status.Rejected;
+    }
+
+    public T getValue() throws Throwable {
+        while (isPending()) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
             }
-            else
-            {
-              // We have fulfilled all the promises. We can return control to the
-              // client so it can continue.
-              settlement.resolve (results);
+        }
+        if(this.rejection_ != null) {
+            throw this.rejection_;
+        }
+        return this.value_;
+    }
+
+    /**
+     * Cancel the promise.
+     *
+     * @return True if cancelled, otherwise false.
+     */
+    public boolean cancel() {
+        return this.cancel(true);
+    }
+
+    /**
+     * Cancel the promise
+     *
+     * @param mayInterruptIfRunning Interrupt promise is running
+     * @return True if cancelled; otherwise false
+     */
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (this.status_ != Status.Pending)
+            return false;
+
+        try {
+            this.stateLock_.writeLock().lock();
+
+            if (this.status_ != Status.Pending)
+                return false;
+
+            boolean result = this.future_.cancel(mayInterruptIfRunning);
+
+            if (result)
+                this.status_ = Status.Cancelled;
+
+            return result;
+        } finally {
+            this.stateLock_.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Add a chain to the promise.
+     *
+     * @param onResolved
+     * @param <U>
+     * @return
+     */
+    public <U> Promise<U> then(OnResolved<T, U> onResolved) {
+        if (onResolved == null)
+            throw new IllegalStateException("The resolve handler cannot be null");
+
+        return this.then(onResolved, null);
+    }
+
+    /**
+     * Add a chain to the promise.
+     *
+     * @param onResolved
+     * @param <U>
+     * @return
+     */
+    public <U> Promise<U> then(OnResolvedExecutor<T, U> onResolved) {
+        if (onResolved == null)
+            throw new IllegalStateException("The resolve handler cannot be null");
+
+        return this.then(onResolved, null);
+    }
+
+    /**
+     * Add a chain to the promise.
+     *
+     * @param onResolved
+     * @param onRejected
+     * @param <U>
+     * @return
+     */
+    public <U> Promise<U> then(OnResolved<T, U> onResolved, OnRejected onRejected) {
+        return this.then(OnResolvedExecutor.wrapOrNull(onResolved), OnRejectedExecutor.wrapOrNull(onRejected));
+    }
+
+    /**
+     * Add an error handler to the chain.
+     *
+     * @param onRejected
+     * @param <U>
+     * @return
+     */
+    public <U> Promise<U> _catch(OnRejected onRejected) {
+        if (onRejected == null)
+            throw new IllegalStateException("The rejected handler cannot be null.");
+
+        return this.then(null, onRejected);
+    }
+
+    /**
+     * Add an error handler to the chain.
+     *
+     * @param onRejected
+     * @param <U>
+     * @return
+     */
+    public <U> Promise<U> _catch(OnRejectedExecutor onRejected) {
+        if (onRejected == null)
+            throw new IllegalStateException("The rejected handler cannot be null.");
+
+        return this.then(null, onRejected);
+    }
+
+    /**
+     * Settle the promise. The promised will either be execute or execute.
+     *
+     * @param onResolved Handler called when execute.
+     * @param onRejected Handler called when execute.
+     */
+    @SuppressWarnings("unchecked")
+    public <U> Promise<U> then(OnResolvedExecutor<T, U> onResolved, OnRejectedExecutor onRejected) {
+        final ContinuationPromise continuation = new ContinuationPromise<>();
+
+        try {
+            // Get the read lock so that t
+            this.stateLock_.readLock().lock();
+
+            if (this.status_ == Status.Resolved) {
+                // The promise is already execute. If the client has provided a handler,
+                // then we need to invoke it and determine how we are to proceed. Otherwise,
+                // we need to continue down the chain with a new start (i.e., a null value).
+                if (onResolved != null)
+                    onResolved.execute(this.executor_, this.value_, continuation);
+                else
+                    continuation.continueWithNull();
+            } else if (this.status_ == Status.Rejected) {
+                // We are handling the rejection as this level. Either we are going to handle
+                // the rejection as this level via a onRejected handler, or we are going to
+                // pass the rejection to the next level.
+                if (onRejected != null)
+                    onRejected.execute(this.executor_, this.rejection_, continuation);
+                else
+                    continuation.continueWith(this.rejection_);
+            } else if (this.status_ == Status.Pending) {
+                // The promise is still pending. We need to add the execute and execute
+                // handlers to the waiting list along with the continuation promise returned
+                // from this call. This ensure the promise from the resolve/execute handlers
+                // is passed to the correct continuation promise.
+                this.pendingEntries_.add(new PendingEntry<>(continuation, onResolved, onRejected));
             }
 
-            return null;
-          }
-        };
+            return continuation;
+        } finally {
+            this.stateLock_.readLock().unlock();
+        }
+    }
 
-        // Start resolving the promises.
-        Promise<?> promise = iterator.next ();
-        promise.then (onResolved, onRejected);
-      }
-    });
-  }
-
-  /**
-   * This method returns a promise that resolves or rejects as soon as one of the
-   * promises in the iterable resolves or rejects, with the value or reason from
-   * that promise.
-   *
-   * @param promises
-   * @param <U>
-   * @return
-   */
-  public static <U> Promise <U> race (Promise <U>... promises)
-  {
-    return race (Arrays.asList (promises));
-  }
-
-  /**
-   * This method returns a promise that resolves or rejects as soon as one of the
-   * promises in the iterable resolves or rejects, with the value or reason from
-   * that promise.
-   *
-   * @param promises
-   * @param <U>
-   * @return
-   */
-  public static <U> Promise <U> race (final List <Promise <U>> promises)
-  {
-    if (promises.isEmpty ())
-      return Promise.resolve (null);
-
-    final Object lock = new Object ();
-
-    return new Promise<U> (new PromiseExecutor<U> ()
-    {
-      @Override
-      public void execute (final Settlement<U> settlement)
-      {
-        final OnResolved <U, ?> onResolved = resolved (new ResolveNoReturn<U> ()
-        {
-          @Override
-          public void resolveNoReturn (U value)
-          {
-            synchronized (lock)
-            {
-              try
-              {
-                settlement.resolve (value);
-              }
-              catch (Exception e)
-              {
-                // Do nothing since we are not the first to finish
-              }
+    /**
+     * Settle the promise.
+     */
+    private void settlePromise() {
+        this.future_ = this.executor_.submit(new Runnable() {
+            @Override
+            public void run() {
+                settlePromiseImpl();
             }
-          }
         });
+    }
 
-        // The first promise in the collection that is execute causes all promises
-        // to be execute.
-        final OnRejected onRejected = rejected (new RejectNoReturn ()
-        {
-          @Override
-          public void rejectNoReturn (Throwable reason)
-          {
-            synchronized (lock)
-            {
-              try
-              {
-                settlement.reject (reason);
-              }
-              catch (Exception e)
-              {
-                // Do nothing since we are not the first to finish
-              }
+    /**
+     * The actual implementation for settling a promise.
+     */
+    private void settlePromiseImpl() {
+        try {
+            // Execute the promise. This method must call either resolve or reject
+            // before this method return. Failure to do so means the promise was not
+            // completed, and in a bad state.
+            this.impl_.execute(new Settlement<T>() {
+                @Override
+                public void resolve(T value) {
+                    onResolve(value);
+                }
+
+                @Override
+                public void reject(Throwable reason) {
+                    onReject(reason);
+                }
+            });
+        } catch (Exception e) {
+            this.onReject(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    void onResolve(T value) {
+        // Check that the promise is still pending. This is an implementation of the
+        // double-checked locking software design pattern.
+        if (this.status_ != Status.Pending)
+            throw new IllegalStateException("Promise must be pending to resolve.");
+
+        try {
+            // Get a write lock to the state since we are updating it. We do not want
+            // other threads reading the state until we are done.
+            this.stateLock_.writeLock().lock();
+
+            // Check that the promise is still pending.
+            if (this.status_ != Status.Pending)
+                throw new IllegalStateException("Promise must be pending to resolve");
+
+            // Cache the result of the promise.
+            this.status_ = Status.Resolved;
+            this.value_ = value;
+        } finally {
+            this.stateLock_.writeLock().unlock();
+        }
+
+        if (!this.pendingEntries_.isEmpty()) {
+            // Let's each of pending entry know we have execute the promise. Afterwards,
+            // we need to clear the pending entry list.
+
+            for (PendingEntry<T> entry : this.pendingEntries_)
+                entry.resolved(this.executor_, value);
+
+            // Clear the list of pending entries.
+            this.pendingEntries_.clear();
+        }
+    }
+
+    /**
+     * Bubble the rejection.
+     *
+     * @param reason
+     */
+    @SuppressWarnings("unchecked")
+    void onReject(Throwable reason) {
+        // Check that the promise is still pending. This is an implementation of the
+        // double-checked locking software design pattern.
+        if (this.status_ != Status.Pending)
+            throw new IllegalStateException("Promise must be pending to resolve");
+
+        try {
+            // Get a write lock to the state since we are updating it. We do not want
+            // other threads reading the state until we are done.
+            this.stateLock_.writeLock().lock();
+
+            // Check that the promise is still pending.
+            if (this.status_ != Status.Pending)
+                throw new IllegalStateException("Promise must be pending to resolve");
+
+            this.rejection_ = reason;
+            this.status_ = Status.Rejected;
+        } finally {
+            this.stateLock_.writeLock().unlock();
+        }
+
+        if (!this.pendingEntries_.isEmpty()) {
+            // Let's each of pending entry know we have execute the promise. Afterwards,
+            // we need to clear the pending entry list.
+
+            for (PendingEntry<T> entry : this.pendingEntries_)
+                entry.rejected(this.executor_, reason);
+
+            // Clear the list of pending entries.
+            this.pendingEntries_.clear();
+        }
+    }
+
+    /**
+     * Create a Promise that is already execute.
+     *
+     * @param value
+     * @param <T>
+     * @return
+     */
+    public static <T> Promise<T> resolve(T value) {
+        return new Promise<>(value);
+    }
+
+    /**
+     * Create a promise that is already execute.
+     *
+     * @param reason
+     * @return
+     */
+    public static <T> Promise<T> reject(Throwable reason) {
+        return new Promise<>(reason);
+    }
+
+    /**
+     * Settle a collection of promises.
+     *
+     * @param promises
+     * @return
+     */
+    public static Promise<List<Object>> all(Promise<?>... promises) {
+        return all(Arrays.asList(promises));
+    }
+
+    /**
+     * Settle a collection of promises.
+     *
+     * @param promises
+     * @return
+     */
+    public static Promise<List<Object>> all(final List<Promise<?>> promises) {
+        if (promises.isEmpty())
+            return Promise.resolve(Collections.emptyList());
+
+        return new Promise<>(new PromiseExecutor<List<Object>>() {
+            @Override
+            public void execute(final Settlement<List<Object>> settlement) {
+                final ArrayList<Object> results = new ArrayList<>(promises.size());
+                final Iterator<Promise<?>> iterator = promises.iterator();
+
+                // The first promise in the collection that is execute causes all promises
+                // to be execute.
+                final OnRejected onRejected = new OnRejected() {
+                    @Override
+                    public Promise onRejected(Throwable reason) {
+                        settlement.reject(reason);
+                        return null;
+                    }
+                };
+
+                final OnResolved onResolved = new OnResolved() {
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    public Promise onResolved(Object value) {
+                        // Add the execute value to the result set.
+                        results.add(value);
+
+                        if (iterator.hasNext()) {
+                            // We have more promises to resolve. So, let's move to the next one and
+                            // attempt to resolve it.
+                            Promise<?> promise = iterator.next();
+                            promise.then(this, onRejected);
+                        } else {
+                            // We have fulfilled all the promises. We can return control to the
+                            // client so it can continue.
+                            settlement.resolve(results);
+                        }
+
+                        return null;
+                    }
+                };
+
+                // Start resolving the promises.
+                Promise<?> promise = iterator.next();
+                promise.then(onResolved, onRejected);
             }
-          }
         });
+    }
 
-        for (Promise <U> promise: promises)
-          promise.then (onResolved, onRejected);
-      }
-    });
-  }
+    /**
+     * This method returns a promise that resolves or rejects as soon as one of the
+     * promises in the iterable resolves or rejects, with the value or reason from
+     * that promise.
+     *
+     * @param promises
+     * @param <U>
+     * @return
+     */
+    public static <U> Promise<U> race(Promise<U>... promises) {
+        return race(Arrays.asList(promises));
+    }
+
+    /**
+     * This method returns a promise that resolves or rejects as soon as one of the
+     * promises in the iterable resolves or rejects, with the value or reason from
+     * that promise.
+     *
+     * @param promises
+     * @param <U>
+     * @return
+     */
+    public static <U> Promise<U> race(final List<Promise<U>> promises) {
+        if (promises.isEmpty())
+            return Promise.resolve(null);
+
+        final Object lock = new Object();
+
+        return new Promise<U>(new PromiseExecutor<U>() {
+            @Override
+            public void execute(final Settlement<U> settlement) {
+                final OnResolved<U, ?> onResolved = resolved(new ResolveNoReturn<U>() {
+                    @Override
+                    public void resolveNoReturn(U value) {
+                        synchronized (lock) {
+                            try {
+                                settlement.resolve(value);
+                            } catch (Exception e) {
+                                // Do nothing since we are not the first to finish
+                            }
+                        }
+                    }
+                });
+
+                // The first promise in the collection that is execute causes all promises
+                // to be execute.
+                final OnRejected onRejected = rejected(new RejectNoReturn() {
+                    @Override
+                    public void rejectNoReturn(Throwable reason) {
+                        synchronized (lock) {
+                            try {
+                                settlement.reject(reason);
+                            } catch (Exception e) {
+                                // Do nothing since we are not the first to finish
+                            }
+                        }
+                    }
+                });
+
+                for (Promise<U> promise : promises)
+                    promise.then(onResolved, onRejected);
+            }
+        });
+    }
 }

--- a/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
+++ b/promises-jvm/src/main/java/com/onehilltech/promises/Promise.java
@@ -345,16 +345,22 @@ public class Promise<T> {
         return this.then(OnResolvedExecutor.wrapOrNull(onResolved), OnRejectedExecutor.wrapOrNull(onRejected));
     }
 
-    public <U> Promise<U> always(OnAlways<U> onAlways) {
-        return this.then((OnResolvedExecutor<T, U>) OnResolvedExecutor.wrapOrNull(
-                (v) -> {
-                    onAlways.OnAlways();
-                    return Promise.resolve(v);
-                }),
-                OnRejectedExecutor.wrapOrNull((e) -> {
-                    onAlways.OnAlways();
-                    return Promise.reject(e);
-                })
+    public <U> Promise<U> always(final OnAlways<U> onAlways) {
+        return this.then(
+                new OnResolved() {
+                     @Override
+                     public Promise onResolved(Object value) {
+                         onAlways.OnAlways();
+                         return Promise.resolve(value);
+                     }
+                 },
+                new OnRejected() {
+                     @Override
+                     public Promise onRejected(Throwable reason) {
+                         onAlways.OnAlways();
+                         return Promise.reject(reason);
+                     }
+                 }
         );
     }
 

--- a/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
+++ b/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
@@ -70,7 +70,17 @@ public class PromiseTest {
         synchronized (this.lock_) {
             Promise<Integer> p = Promise.resolve(7);
 
-            p.always(new OnAlways<Integer>() {
+            p.then(new OnResolved<Integer, Integer>() {
+                @Override
+                public Promise onResolved(Integer value) {
+                    return Promise.resolve(value);
+                }
+            })._catch(new Promise.OnRejected() {
+                @Override
+                public Promise onRejected(Throwable reason) {
+                    return null;
+                }
+            }).always(new OnAlways<Integer>() {
                 @Override
                 public void OnAlways() {
                     synchronized (lock_) {
@@ -653,7 +663,7 @@ public class PromiseTest {
                     .then(resolved(new ResolveNoReturn<Object>() {
                         @Override
                         public void resolveNoReturn(Object value) {
-                            Assert.assertNull(value);
+                            Assert.assertEquals(50, value);
 
                             isComplete_ = true;
 
@@ -795,7 +805,7 @@ public class PromiseTest {
                     .then(resolved(new ResolveNoReturn<Object>() {
                         @Override
                         public void resolveNoReturn(Object value) {
-                            Assert.assertNull(value);
+                            Assert.assertEquals(5, value);
 
                             isComplete_ = true;
 

--- a/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
+++ b/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
@@ -11,983 +11,830 @@ import static com.onehilltech.promises.Promise.ignoreReason;
 import static com.onehilltech.promises.Promise.rejected;
 import static com.onehilltech.promises.Promise.resolved;
 
-public class PromiseTest
-{
-  private final Object lock_ = new Object ();
-  private boolean isComplete_;
-  private int counter_;
+public class PromiseTest {
+    private final Object lock_ = new Object();
+    private boolean isComplete_;
+    private int counter_;
 
-  @Before
-  public void setup ()
-  {
-    this.isComplete_ = false;
-    this.counter_ = 0;
-  }
+    @Before
+    public void setup() {
+        this.isComplete_ = false;
+        this.counter_ = 0;
+    }
 
-  @Test
-  public void testThenResolve () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise <Integer> p = Promise.resolve (7);
+    @Test
+    public void testSynchronousGetValueSuccess() {
+        int expected = 123;
+        Promise<Integer> promise = new Promise < > (settlement -> {
+            settlement.resolve(expected);
+        });
+        try {
+            int value = promise.getValue();
+            Assert.assertEquals(expected, value);
+        } catch (Throwable throwable) {
+            Assert.fail();
+        }
+    }
 
-      p.then (
-          resolved (new ResolveNoReturn<Integer> ()
-          {
+    @Test
+    public void testSynchronousGetValueFail() {
+        String expected = "getValue should throw an exception";
+        Promise<Integer> promise = new Promise < > (settlement -> {
+            settlement.reject(new Exception(expected));
+        });
+        try {
+            int value = promise.getValue();
+            Assert.fail();
+        } catch (Throwable throwable) {
+            Assert.assertEquals(throwable.getMessage(), expected);
+        }
+    }
+
+    @Test
+    public void testThenResolve() throws Exception {
+        synchronized (this.lock_) {
+            Promise<Integer> p = Promise.resolve(7);
+
+            p.then(
+                    resolved(new ResolveNoReturn<Integer>() {
+                        @Override
+                        public void resolveNoReturn(Integer value) {
+                            isComplete_ = true;
+                            Assert.assertEquals(7, (int) value);
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+            Assert.assertEquals(Promise.Status.Resolved, p.getStatus());
+        }
+    }
+
+    @Test
+    public void testThenReject() throws Exception {
+        synchronized (this.lock_) {
+            Promise<Integer> p = Promise.reject(new IllegalStateException());
+
+            p.then(new OnResolved<Integer, Integer>() {
+                @Override
+                public Promise<Integer> onResolved(Integer value) {
+                    return Promise.resolve(5);
+                }
+            }, rejected(new RejectNoReturn() {
+                @Override
+                public void rejectNoReturn(Throwable reason) {
+                    isComplete_ = true;
+
+                    synchronized (lock_) {
+                        Assert.assertEquals(IllegalStateException.class, reason.getClass());
+
+                        lock_.notify();
+                    }
+                }
+            }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testMultipleThen() throws Exception {
+        final Promise<Integer> p1 = new Promise<>(new PromiseExecutor<Integer>() {
             @Override
-            public void resolveNoReturn (Integer value)
-            {
-              isComplete_ = true;
-              Assert.assertEquals (7, (int)value);
-
-              synchronized (lock_)
-              {
-                lock_.notify ();
-              }
-            }
-          }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-      Assert.assertEquals (Promise.Status.Resolved, p.getStatus ());
-    }
-  }
-
-  @Test
-  public void testThenReject () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise <Integer> p = Promise.reject (new IllegalStateException ());
-
-      p.then (new OnResolved<Integer, Integer> () {
-        @Override
-        public Promise<Integer> onResolved (Integer value)
-        {
-          return Promise.resolve (5);
-        }
-      }, rejected (new RejectNoReturn () {
-        @Override
-        public void rejectNoReturn (Throwable reason)
-        {
-          isComplete_ = true;
-
-          synchronized (lock_)
-          {
-            Assert.assertEquals (IllegalStateException.class, reason.getClass ());
-
-            lock_.notify ();
-          }
-        }
-      }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testMultipleThen () throws Exception
-  {
-    final Promise <Integer> p1 = new Promise<> (new PromiseExecutor<Integer> ()
-    {
-      @Override
-      public void execute (Promise.Settlement<Integer> settlement)
-      {
-        try
-        {
-          Thread.sleep (30);
-          settlement.resolve (1);
-        }
-        catch (Exception e)
-        {
-          settlement.reject (e);
-        }
-      }
-    });
-
-    final Promise <Integer> p2 = new Promise<> (new PromiseExecutor<Integer> ()
-    {
-      @Override
-      public void execute (Promise.Settlement<Integer> settlement)
-      {
-        try
-        {
-          Thread.sleep (30);
-          settlement.resolve (2);
-        }
-        catch (Exception e)
-        {
-          settlement.reject (e);
-        }
-      }
-    });
-
-    final Promise <Integer> p3 = new Promise<> (new PromiseExecutor<Integer> ()
-    {
-      @Override
-      public void execute (Promise.Settlement<Integer> settlement)
-      {
-        try
-        {
-          Thread.sleep (30);
-          settlement.resolve (3);
-        }
-        catch (Exception e)
-        {
-          settlement.reject (e);
-        }
-      }
-    });
-
-    final Promise <Integer> p4 = new Promise<> (new PromiseExecutor<Integer> ()
-    {
-      @Override
-      public void execute (Promise.Settlement<Integer> settlement)
-      {
-        try
-        {
-          Thread.sleep (30);
-          settlement.resolve (4);
-        }
-        catch (Exception e)
-        {
-          settlement.reject (e);
-        }
-      }
-    });
-
-    synchronized (this.lock_)
-    {
-      p1.then (new OnResolved<Integer, Integer> () {
-        @Override
-        public Promise<Integer> onResolved (Integer value)
-        {
-          return p2;
-        }
-      }).then (new OnResolved<Integer, Integer> () {
-        @Override
-        public Promise<Integer> onResolved (Integer value)
-        {
-          return p3;
-        }
-      }).then (new OnResolved<Integer, Integer> () {
-        @Override
-        public Promise<Integer> onResolved (Integer value)
-        {
-          return p4;
-        }
-      }).then (resolved (new ResolveNoReturn<Integer> () {
-        @Override
-        public void resolveNoReturn (Integer value)
-        {
-          Assert.assertEquals (4, value.intValue ());
-
-          isComplete_ = true;
-
-          synchronized (lock_)
-          {
-            lock_.notify ();
-          }
-        }
-      }))._catch (rejected (new RejectNoReturn () {
-        @Override
-        public void rejectNoReturn (Throwable reason)
-        {
-          Assert.fail ();
-        }
-      }));
-
-      this.lock_.wait ();
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testAll () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise<List<Object>> p =
-          Promise.all (
-              new Promise<> (new PromiseExecutor<Integer> () {
-                @Override
-                public void execute (Promise.Settlement<Integer> settlement)
-                {
-                  settlement.resolve (10);
+            public void execute(Promise.Settlement<Integer> settlement) {
+                try {
+                    Thread.sleep(30);
+                    settlement.resolve(1);
+                } catch (Exception e) {
+                    settlement.reject(e);
                 }
-              }),
-              new Promise<> (new PromiseExecutor<Integer> () {
-                @Override
-                public void execute (Promise.Settlement<Integer> settlement)
-                {
-                  settlement.resolve (20);
-                }
-              }));
-
-      p.then (resolved (new ResolveNoReturn<List<Object>> ()
-      {
-        @Override
-        public void resolveNoReturn (List<Object> value)
-        {
-          Assert.assertEquals (2, value.size ());
-
-          Assert.assertEquals (10, value.get (0));
-          Assert.assertEquals (20, value.get (1));
-
-          isComplete_ = true;
-
-          synchronized (lock_)
-          {
-            lock_.notify ();
-          }
-        }
-      }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testAllAsContinuation () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      // Create a LOT of promises.
-      final ArrayList<Promise <?>> promises = new ArrayList<> ();
-
-      for (int i = 0; i < 7; ++ i)
-      {
-        Promise <Integer> p = new Promise<> (new PromiseExecutor<Integer> ()
-        {
-          @Override
-          public void execute (Promise.Settlement<Integer> settlement)
-          {
-            try
-            {
-              Thread.sleep (30);
-              settlement.resolve (10);
             }
-            catch (Exception e)
-            {
-              settlement.reject (e);
-            }
-          }
         });
 
-        promises.add (p);
-      }
-
-      final Promise <Integer> start = new Promise<> (new PromiseExecutor<Integer> ()
-      {
-        @Override
-        public void execute (Promise.Settlement<Integer> settlement)
-        {
-          try
-          {
-            Thread.sleep (40);
-            settlement.resolve (20);
-          }
-          catch (Exception e)
-          {
-            settlement.reject (e);
-          }
-        }
-      });
-
-      final Promise <Integer> middle = new Promise<> (new PromiseExecutor<Integer> ()
-      {
-        @Override
-        public void execute (Promise.Settlement<Integer> settlement)
-        {
-          try
-          {
-            Thread.sleep (40);
-            settlement.resolve (20);
-          }
-          catch (Exception e)
-          {
-            settlement.reject (e);
-          }
-        }
-      });
-
-      start.then (new OnResolved<Integer, Integer> () {
-        @Override
-        public Promise<Integer> onResolved (Integer value)
-        {
-          return middle;
-        }
-      }).then (new OnResolved<Integer, List <Object>> () {
-        @Override
-        public Promise<List <Object>> onResolved (Integer value)
-        {
-          return Promise.all (promises);
-        }
-      }).then (resolved (new ResolveNoReturn<List<Object>> ()
-      {
-        @Override
-        public void resolveNoReturn (List<Object> result)
-        {
-          isComplete_ = true;
-
-          Assert.assertEquals (promises.size (), result.size ());
-
-          for (int i = 0; i < result.size (); ++ i)
-            Assert.assertEquals (10, result.get (i));
-
-          synchronized (lock_)
-          {
-            lock_.notify ();
-          }
-        }
-      }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testStaticResolve ()
-  {
-    Promise <Integer> p = Promise.resolve (7);
-    Assert.assertEquals (Promise.Status.Resolved, p.getStatus ());
-  }
-
-  @Test
-  public void testStaticReject ()
-  {
-    Promise <?> p = Promise.reject (new IllegalStateException ());
-    Assert.assertEquals (Promise.Status.Rejected, p.getStatus ());
-  }
-
-  @Test
-  public void testRejectOnly () throws Exception
-  {
-    Promise.reject (new IllegalStateException ())
-           ._catch (rejected (new RejectNoReturn ()
-           {
-             @Override
-             public void rejectNoReturn (Throwable reason)
-             {
-               isComplete_ = true;
-               Assert.assertEquals (reason.getClass (), IllegalStateException.class);
-
-               synchronized (lock_)
-               {
-                 lock_.notify ();
-               }
-             }
-           }));
-
-    synchronized (this.lock_)
-    {
-      this.lock_.wait (5000);
-    }
-
-    Assert.assertTrue (this.isComplete_);
-  }
-
-  @Test
-  public void testPromiseChainTyped () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      OnResolved<String, Long> completion1 = new OnResolved<String, Long> ()
-      {
-        @Override
-        public Promise<Long> onResolved (String str)
-        {
-          Assert.assertEquals ("Hello, World", str);
-          return Promise.resolve (10L);
-        }
-      };
-
-      OnResolved<Long, Void> completion2 = resolved (new ResolveNoReturn<Long> ()
-      {
-        @Override
-        public void resolveNoReturn (Long value)
-        {
-          Assert.assertEquals (10L, (long)value);
-          isComplete_ = true;
-
-          synchronized (lock_)
-          {
-            lock_.notify ();
-          }
-        }
-      });
-
-      Promise.resolve ("Hello, World")
-             .then (completion1)
-             .then (completion2);
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testPromiseChain () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.resolve ("Hello, World")
-             .then (new OnResolved<String, Integer> () {
-               @Override
-               public Promise<Integer> onResolved (String str)
-               {
-                 Assert.assertEquals ("Hello, World", str);
-                 return Promise.resolve (10);
-               }
-             })
-             .then (resolved (new ResolveNoReturn<Integer> ()
-             {
-               @Override
-               public void resolveNoReturn (Integer value)
-               {
-                 // n is of type long, but assertEquals has ambiguous calls.
-                 Assert.assertEquals (10, value.intValue ());
-
-                 synchronized (lock_)
-                 {
-                   isComplete_ = true;
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testPromiseChainNoContinuation () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.resolve ("Hello, World")
-             .then (resolved (new ResolveNoReturn<String> () {
-               @Override
-               public void resolveNoReturn (String str)
-               {
-                 Assert.assertEquals ("Hello, World", str);
-               }
-             }))
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertNull (value);
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testBubbleRejection () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.reject (new IllegalStateException ("GREAT"))
-             .then (new OnResolved<Object, Integer> () {
-               @Override
-               public Promise<Integer> onResolved (Object value)
-               {
-                 Assert.fail ();
-                 return Promise.resolve (10);
-               }
-             })
-             .then (new OnResolved<Integer, Integer> () {
-               @Override
-               public Promise<Integer> onResolved (Integer value)
-               {
-                 Assert.fail ();
-                 return Promise.resolve (40);
-               }
-             })
-             ._catch (rejected (new RejectNoReturn ()
-             {
-               @Override
-               public void rejectNoReturn (Throwable reason)
-               {
-                 Assert.assertEquals (IllegalStateException.class, reason.getClass ());
-                 Assert.assertEquals ("GREAT", reason.getLocalizedMessage ());
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testStopAtFirstCatch () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.reject (new IllegalStateException ("GREAT"))
-             .then (new OnResolved<Object, Integer> () {
-               @Override
-               public Promise<Integer> onResolved (Object value)
-               {
-                 Assert.fail ();
-                 return Promise.resolve (10);
-               }
-             })
-             .then (new OnResolved<Integer, Integer> () {
-               @Override
-               public Promise<Integer> onResolved (Integer value)
-               {
-                 Assert.fail ();
-                 return Promise.resolve (40);
-               }
-             })
-             ._catch (rejected (new RejectNoReturn ()
-             {
-               @Override
-               public void rejectNoReturn (Throwable reason)
-               {
-                 Assert.assertEquals (IllegalStateException.class, reason.getClass ());
-                 Assert.assertEquals ("GREAT", reason.getLocalizedMessage ());
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }))
-             ._catch (rejected (new RejectNoReturn ()
-             {
-               @Override
-               public void rejectNoReturn (Throwable reason)
-               {
-                 Assert.fail ();
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-
-      this.lock_.wait (1000);
-    }
-  }
-
-
-  @Test
-  public void testThenAfterCatchWithContinuationValue () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.reject (new IllegalStateException ())
-             ._catch (new Promise.OnRejected () {
-               @Override
-               public Promise onRejected (Throwable reason)
-               {
-                 Assert.assertEquals (IllegalStateException.class, reason.getClass ());
-                 return Promise.resolve (10);
-               }
-             })
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertEquals (10, value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testThenAfterRejectShouldNotWork () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.reject (new IllegalStateException ())
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertNull (value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (500);
-
-      Assert.assertFalse (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testRejectCatchThen () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.reject (new IllegalStateException ())
-             ._catch (rejected (new RejectNoReturn () {
-               @Override
-               public void rejectNoReturn (Throwable reason)
-               {
-                 Assert.assertEquals (IllegalStateException.class, reason.getClass ());
-               }
-             }))
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertNull (value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testResolveCatchThen () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.resolve (50)
-             ._catch (rejected (new RejectNoReturn () {
-               @Override
-               public void rejectNoReturn (Throwable reason)
-               {
-                 Assert.fail ();
-               }
-             }))
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertNull (value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testThenAfterCatch () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.reject (new IllegalStateException ())
-             ._catch (rejected (new RejectNoReturn () {
-               @Override
-               public void rejectNoReturn (Throwable reason)
-               {
-                 Assert.assertEquals (IllegalStateException.class, reason.getClass ());
-               }
-             }))
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertNull (value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testRaceEmpty () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.race (new ArrayList<Promise<Integer>> ())
-             .then (resolved (new ResolveNoReturn<Integer> ()
-             {
-               @Override
-               public void resolveNoReturn (Integer value)
-               {
-                 Assert.assertNull (value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testRace () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise<Integer> p =
-          Promise.race (
-              new Promise<> (new PromiseExecutor<Integer> ()
-              {
-                @Override
-                public void execute (Promise.Settlement<Integer> settlement)
-                {
-                  try
-                  {
-                    Thread.sleep (500);
-                    settlement.resolve (10);
-                  }
-                  catch (InterruptedException e)
-                  {
-                    settlement.reject (e);
-                  }
-                }
-              }),
-              new Promise<> (new PromiseExecutor<Integer> ()
-              {
-                @Override
-                public void execute (Promise.Settlement<Integer> settlement)
-                {
-                  try
-                  {
-                    Thread.sleep (300);
-                    settlement.resolve (20);
-                  }
-                  catch (InterruptedException e)
-                  {
-                    settlement.reject (e);
-                  }
-                }
-              }),
-              new Promise<> (new PromiseExecutor<Integer> ()
-              {
-                @Override
-                public void execute (Promise.Settlement<Integer> settlement)
-                {
-                  try
-                  {
-                    Thread.sleep (600);
-                    settlement.resolve (30);
-                  }
-                  catch (InterruptedException e)
-                  {
-                    settlement.reject (e);
-                  }
-                }
-              })
-          );
-
-      p.then (resolved (new ResolveNoReturn<Integer> () {
-        @Override
-        public void resolveNoReturn (Integer value)
-        {
-          Assert.assertEquals (20, (int)value);
-
-          Assert.assertFalse (isComplete_);
-          isComplete_ = true;
-
-          synchronized (lock_)
-          {
-            lock_.notify ();
-          }
-        }
-      }))
-      ._catch (rejected (new RejectNoReturn () {
-        @Override
-        public void rejectNoReturn (Throwable reason)
-        {
-          Assert.fail ();
-        }
-      }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testResolveCatchIgnoreThen () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise.resolve (5)
-             ._catch (ignoreReason)
-             .then (resolved (new ResolveNoReturn<Object> () {
-               @Override
-               public void resolveNoReturn (Object value)
-               {
-                 Assert.assertNull (value);
-
-                 isComplete_ = true;
-
-                 synchronized (lock_)
-                 {
-                   lock_.notify ();
-                 }
-               }
-             }));
-
-      this.lock_.wait (5000);
-
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  @Test
-  public void testCancel () throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      Promise<Integer> p1 = new Promise<> (new PromiseExecutor<Integer> ()
-      {
-        @Override
-        public void execute (Promise.Settlement<Integer> settlement)
-        {
-          try
-          {
-            Thread.sleep (300);
-          }
-          catch (InterruptedException e)
-          {
-            isComplete_ = true;
-          }
-        }
-      });
-
-      Thread.sleep (100);
-      p1.cancel (true);
-
-      p1.then (new OnResolved<Integer, Object> ()
-      {
-        @Override
-        public Promise<Object> onResolved (Integer value)
-        {
-          isComplete_ = false;
-          return null;
-        }
-      });
-
-      this.lock_.wait (100);
-
-      Assert.assertTrue (p1.isCancelled ());
-      Assert.assertTrue (this.isComplete_);
-    }
-  }
-
-  public void testNestedPromise ()
-      throws Exception
-  {
-    synchronized (this.lock_)
-    {
-      this.makeSimplePromise (25)
-          .then (new OnResolved<Integer, Integer> () {
+        final Promise<Integer> p2 = new Promise<>(new PromiseExecutor<Integer>() {
             @Override
-            public Promise<Integer> onResolved (final Integer value)
-            {
-              return new Promise<> (new PromiseExecutor<Integer> ()
-              {
-                @Override
-                public void execute (Promise.Settlement<Integer> settlement)
-                {
-                  settlement.resolve (value);
+            public void execute(Promise.Settlement<Integer> settlement) {
+                try {
+                    Thread.sleep(30);
+                    settlement.resolve(2);
+                } catch (Exception e) {
+                    settlement.reject(e);
                 }
-              });
             }
-          });
+        });
 
-      this.lock_.wait (10000);
+        final Promise<Integer> p3 = new Promise<>(new PromiseExecutor<Integer>() {
+            @Override
+            public void execute(Promise.Settlement<Integer> settlement) {
+                try {
+                    Thread.sleep(30);
+                    settlement.resolve(3);
+                } catch (Exception e) {
+                    settlement.reject(e);
+                }
+            }
+        });
 
-      Assert.assertTrue (this.isComplete_);
+        final Promise<Integer> p4 = new Promise<>(new PromiseExecutor<Integer>() {
+            @Override
+            public void execute(Promise.Settlement<Integer> settlement) {
+                try {
+                    Thread.sleep(30);
+                    settlement.resolve(4);
+                } catch (Exception e) {
+                    settlement.reject(e);
+                }
+            }
+        });
+
+        synchronized (this.lock_) {
+            p1.then(new OnResolved<Integer, Integer>() {
+                @Override
+                public Promise<Integer> onResolved(Integer value) {
+                    return p2;
+                }
+            }).then(new OnResolved<Integer, Integer>() {
+                @Override
+                public Promise<Integer> onResolved(Integer value) {
+                    return p3;
+                }
+            }).then(new OnResolved<Integer, Integer>() {
+                @Override
+                public Promise<Integer> onResolved(Integer value) {
+                    return p4;
+                }
+            }).then(resolved(new ResolveNoReturn<Integer>() {
+                @Override
+                public void resolveNoReturn(Integer value) {
+                    Assert.assertEquals(4, value.intValue());
+
+                    isComplete_ = true;
+
+                    synchronized (lock_) {
+                        lock_.notify();
+                    }
+                }
+            }))._catch(rejected(new RejectNoReturn() {
+                @Override
+                public void rejectNoReturn(Throwable reason) {
+                    Assert.fail();
+                }
+            }));
+
+            this.lock_.wait();
+
+            Assert.assertTrue(this.isComplete_);
+        }
     }
-  }
 
-  private Promise <Integer> makeSimplePromise (final int value)
-  {
-    return new Promise<> (new PromiseExecutor<Integer> ()
-    {
-      @Override
-      public void execute (Promise.Settlement<Integer> settlement)
-      {
-        settlement.resolve (value);
-      }
-    });
-  }
+    @Test
+    public void testAll() throws Exception {
+        synchronized (this.lock_) {
+            Promise<List<Object>> p =
+                    Promise.all(
+                            new Promise<>(new PromiseExecutor<Integer>() {
+                                @Override
+                                public void execute(Promise.Settlement<Integer> settlement) {
+                                    settlement.resolve(10);
+                                }
+                            }),
+                            new Promise<>(new PromiseExecutor<Integer>() {
+                                @Override
+                                public void execute(Promise.Settlement<Integer> settlement) {
+                                    settlement.resolve(20);
+                                }
+                            }));
+
+            p.then(resolved(new ResolveNoReturn<List<Object>>() {
+                @Override
+                public void resolveNoReturn(List<Object> value) {
+                    Assert.assertEquals(2, value.size());
+
+                    Assert.assertEquals(10, value.get(0));
+                    Assert.assertEquals(20, value.get(1));
+
+                    isComplete_ = true;
+
+                    synchronized (lock_) {
+                        lock_.notify();
+                    }
+                }
+            }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testAllAsContinuation() throws Exception {
+        synchronized (this.lock_) {
+            // Create a LOT of promises.
+            final ArrayList<Promise<?>> promises = new ArrayList<>();
+
+            for (int i = 0; i < 7; ++i) {
+                Promise<Integer> p = new Promise<>(new PromiseExecutor<Integer>() {
+                    @Override
+                    public void execute(Promise.Settlement<Integer> settlement) {
+                        try {
+                            Thread.sleep(30);
+                            settlement.resolve(10);
+                        } catch (Exception e) {
+                            settlement.reject(e);
+                        }
+                    }
+                });
+
+                promises.add(p);
+            }
+
+            final Promise<Integer> start = new Promise<>(new PromiseExecutor<Integer>() {
+                @Override
+                public void execute(Promise.Settlement<Integer> settlement) {
+                    try {
+                        Thread.sleep(40);
+                        settlement.resolve(20);
+                    } catch (Exception e) {
+                        settlement.reject(e);
+                    }
+                }
+            });
+
+            final Promise<Integer> middle = new Promise<>(new PromiseExecutor<Integer>() {
+                @Override
+                public void execute(Promise.Settlement<Integer> settlement) {
+                    try {
+                        Thread.sleep(40);
+                        settlement.resolve(20);
+                    } catch (Exception e) {
+                        settlement.reject(e);
+                    }
+                }
+            });
+
+            start.then(new OnResolved<Integer, Integer>() {
+                @Override
+                public Promise<Integer> onResolved(Integer value) {
+                    return middle;
+                }
+            }).then(new OnResolved<Integer, List<Object>>() {
+                @Override
+                public Promise<List<Object>> onResolved(Integer value) {
+                    return Promise.all(promises);
+                }
+            }).then(resolved(new ResolveNoReturn<List<Object>>() {
+                @Override
+                public void resolveNoReturn(List<Object> result) {
+                    isComplete_ = true;
+
+                    Assert.assertEquals(promises.size(), result.size());
+
+                    for (int i = 0; i < result.size(); ++i)
+                        Assert.assertEquals(10, result.get(i));
+
+                    synchronized (lock_) {
+                        lock_.notify();
+                    }
+                }
+            }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testStaticResolve() {
+        Promise<Integer> p = Promise.resolve(7);
+        Assert.assertEquals(Promise.Status.Resolved, p.getStatus());
+    }
+
+    @Test
+    public void testStaticReject() {
+        Promise<?> p = Promise.reject(new IllegalStateException());
+        Assert.assertEquals(Promise.Status.Rejected, p.getStatus());
+    }
+
+    @Test
+    public void testRejectOnly() throws Exception {
+        Promise.reject(new IllegalStateException())
+                ._catch(rejected(new RejectNoReturn() {
+                    @Override
+                    public void rejectNoReturn(Throwable reason) {
+                        isComplete_ = true;
+                        Assert.assertEquals(reason.getClass(), IllegalStateException.class);
+
+                        synchronized (lock_) {
+                            lock_.notify();
+                        }
+                    }
+                }));
+
+        synchronized (this.lock_) {
+            this.lock_.wait(5000);
+        }
+
+        Assert.assertTrue(this.isComplete_);
+    }
+
+    @Test
+    public void testPromiseChainTyped() throws Exception {
+        synchronized (this.lock_) {
+            OnResolved<String, Long> completion1 = new OnResolved<String, Long>() {
+                @Override
+                public Promise<Long> onResolved(String str) {
+                    Assert.assertEquals("Hello, World", str);
+                    return Promise.resolve(10L);
+                }
+            };
+
+            OnResolved<Long, Void> completion2 = resolved(new ResolveNoReturn<Long>() {
+                @Override
+                public void resolveNoReturn(Long value) {
+                    Assert.assertEquals(10L, (long) value);
+                    isComplete_ = true;
+
+                    synchronized (lock_) {
+                        lock_.notify();
+                    }
+                }
+            });
+
+            Promise.resolve("Hello, World")
+                    .then(completion1)
+                    .then(completion2);
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testPromiseChain() throws Exception {
+        synchronized (this.lock_) {
+            Promise.resolve("Hello, World")
+                    .then(new OnResolved<String, Integer>() {
+                        @Override
+                        public Promise<Integer> onResolved(String str) {
+                            Assert.assertEquals("Hello, World", str);
+                            return Promise.resolve(10);
+                        }
+                    })
+                    .then(resolved(new ResolveNoReturn<Integer>() {
+                        @Override
+                        public void resolveNoReturn(Integer value) {
+                            // n is of type long, but assertEquals has ambiguous calls.
+                            Assert.assertEquals(10, value.intValue());
+
+                            synchronized (lock_) {
+                                isComplete_ = true;
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testPromiseChainNoContinuation() throws Exception {
+        synchronized (this.lock_) {
+            Promise.resolve("Hello, World")
+                    .then(resolved(new ResolveNoReturn<String>() {
+                        @Override
+                        public void resolveNoReturn(String str) {
+                            Assert.assertEquals("Hello, World", str);
+                        }
+                    }))
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertNull(value);
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testBubbleRejection() throws Exception {
+        synchronized (this.lock_) {
+            Promise.reject(new IllegalStateException("GREAT"))
+                    .then(new OnResolved<Object, Integer>() {
+                        @Override
+                        public Promise<Integer> onResolved(Object value) {
+                            Assert.fail();
+                            return Promise.resolve(10);
+                        }
+                    })
+                    .then(new OnResolved<Integer, Integer>() {
+                        @Override
+                        public Promise<Integer> onResolved(Integer value) {
+                            Assert.fail();
+                            return Promise.resolve(40);
+                        }
+                    })
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.assertEquals(IllegalStateException.class, reason.getClass());
+                            Assert.assertEquals("GREAT", reason.getLocalizedMessage());
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testStopAtFirstCatch() throws Exception {
+        synchronized (this.lock_) {
+            Promise.reject(new IllegalStateException("GREAT"))
+                    .then(new OnResolved<Object, Integer>() {
+                        @Override
+                        public Promise<Integer> onResolved(Object value) {
+                            Assert.fail();
+                            return Promise.resolve(10);
+                        }
+                    })
+                    .then(new OnResolved<Integer, Integer>() {
+                        @Override
+                        public Promise<Integer> onResolved(Integer value) {
+                            Assert.fail();
+                            return Promise.resolve(40);
+                        }
+                    })
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.assertEquals(IllegalStateException.class, reason.getClass());
+                            Assert.assertEquals("GREAT", reason.getLocalizedMessage());
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }))
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.fail();
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+
+            this.lock_.wait(1000);
+        }
+    }
+
+
+    @Test
+    public void testThenAfterCatchWithContinuationValue() throws Exception {
+        synchronized (this.lock_) {
+            Promise.reject(new IllegalStateException())
+                    ._catch(new Promise.OnRejected() {
+                        @Override
+                        public Promise onRejected(Throwable reason) {
+                            Assert.assertEquals(IllegalStateException.class, reason.getClass());
+                            return Promise.resolve(10);
+                        }
+                    })
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertEquals(10, value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testThenAfterRejectShouldNotWork() throws Exception {
+        synchronized (this.lock_) {
+            Promise.reject(new IllegalStateException())
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertNull(value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(500);
+
+            Assert.assertFalse(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testRejectCatchThen() throws Exception {
+        synchronized (this.lock_) {
+            Promise.reject(new IllegalStateException())
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.assertEquals(IllegalStateException.class, reason.getClass());
+                        }
+                    }))
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertNull(value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testResolveCatchThen() throws Exception {
+        synchronized (this.lock_) {
+            Promise.resolve(50)
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.fail();
+                        }
+                    }))
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertNull(value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testThenAfterCatch() throws Exception {
+        synchronized (this.lock_) {
+            Promise.reject(new IllegalStateException())
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.assertEquals(IllegalStateException.class, reason.getClass());
+                        }
+                    }))
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertNull(value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testRaceEmpty() throws Exception {
+        synchronized (this.lock_) {
+            Promise.race(new ArrayList<Promise<Integer>>())
+                    .then(resolved(new ResolveNoReturn<Integer>() {
+                        @Override
+                        public void resolveNoReturn(Integer value) {
+                            Assert.assertNull(value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testRace() throws Exception {
+        synchronized (this.lock_) {
+            Promise<Integer> p =
+                    Promise.race(
+                            new Promise<>(new PromiseExecutor<Integer>() {
+                                @Override
+                                public void execute(Promise.Settlement<Integer> settlement) {
+                                    try {
+                                        Thread.sleep(500);
+                                        settlement.resolve(10);
+                                    } catch (InterruptedException e) {
+                                        settlement.reject(e);
+                                    }
+                                }
+                            }),
+                            new Promise<>(new PromiseExecutor<Integer>() {
+                                @Override
+                                public void execute(Promise.Settlement<Integer> settlement) {
+                                    try {
+                                        Thread.sleep(300);
+                                        settlement.resolve(20);
+                                    } catch (InterruptedException e) {
+                                        settlement.reject(e);
+                                    }
+                                }
+                            }),
+                            new Promise<>(new PromiseExecutor<Integer>() {
+                                @Override
+                                public void execute(Promise.Settlement<Integer> settlement) {
+                                    try {
+                                        Thread.sleep(600);
+                                        settlement.resolve(30);
+                                    } catch (InterruptedException e) {
+                                        settlement.reject(e);
+                                    }
+                                }
+                            })
+                    );
+
+            p.then(resolved(new ResolveNoReturn<Integer>() {
+                @Override
+                public void resolveNoReturn(Integer value) {
+                    Assert.assertEquals(20, (int) value);
+
+                    Assert.assertFalse(isComplete_);
+                    isComplete_ = true;
+
+                    synchronized (lock_) {
+                        lock_.notify();
+                    }
+                }
+            }))
+                    ._catch(rejected(new RejectNoReturn() {
+                        @Override
+                        public void rejectNoReturn(Throwable reason) {
+                            Assert.fail();
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testResolveCatchIgnoreThen() throws Exception {
+        synchronized (this.lock_) {
+            Promise.resolve(5)
+                    ._catch(ignoreReason)
+                    .then(resolved(new ResolveNoReturn<Object>() {
+                        @Override
+                        public void resolveNoReturn(Object value) {
+                            Assert.assertNull(value);
+
+                            isComplete_ = true;
+
+                            synchronized (lock_) {
+                                lock_.notify();
+                            }
+                        }
+                    }));
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testCancel() throws Exception {
+        synchronized (this.lock_) {
+            Promise<Integer> p1 = new Promise<>(new PromiseExecutor<Integer>() {
+                @Override
+                public void execute(Promise.Settlement<Integer> settlement) {
+                    try {
+                        Thread.sleep(300);
+                    } catch (InterruptedException e) {
+                        isComplete_ = true;
+                    }
+                }
+            });
+
+            Thread.sleep(100);
+            p1.cancel(true);
+
+            p1.then(new OnResolved<Integer, Object>() {
+                @Override
+                public Promise<Object> onResolved(Integer value) {
+                    isComplete_ = false;
+                    return null;
+                }
+            });
+
+            this.lock_.wait(100);
+
+            Assert.assertTrue(p1.isCancelled());
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    public void testNestedPromise()
+            throws Exception {
+        synchronized (this.lock_) {
+            this.makeSimplePromise(25)
+                    .then(new OnResolved<Integer, Integer>() {
+                        @Override
+                        public Promise<Integer> onResolved(final Integer value) {
+                            return new Promise<>(new PromiseExecutor<Integer>() {
+                                @Override
+                                public void execute(Promise.Settlement<Integer> settlement) {
+                                    settlement.resolve(value);
+                                }
+                            });
+                        }
+                    });
+
+            this.lock_.wait(10000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    private Promise<Integer> makeSimplePromise(final int value) {
+        return new Promise<>(new PromiseExecutor<Integer>() {
+            @Override
+            public void execute(Promise.Settlement<Integer> settlement) {
+                settlement.resolve(value);
+            }
+        });
+    }
 }

--- a/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
+++ b/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.onehilltech.promises.Promise.ignoreReason;
 import static com.onehilltech.promises.Promise.rejected;
@@ -47,6 +48,42 @@ public class PromiseTest {
             Assert.fail();
         } catch (Throwable throwable) {
             Assert.assertEquals(throwable.getMessage(), expected);
+        }
+    }
+
+    @Test
+    public void testAlwaysSuccess() throws Exception {
+        synchronized (this.lock_) {
+            Promise<Integer> p = Promise.resolve(7);
+
+            p.always(() -> {
+                synchronized (lock_) {
+                    isComplete_ = true;
+                    lock_.notify();
+                }
+            });
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
+        }
+    }
+
+    @Test
+    public void testAlwaysFail() throws Exception {
+        synchronized (this.lock_) {
+            Promise<Integer> p = Promise.resolve(7);
+
+            p.always(() -> {
+                synchronized (lock_) {
+                    isComplete_ = true;
+                    lock_.notify();
+                }
+            });
+
+            this.lock_.wait(5000);
+
+            Assert.assertTrue(this.isComplete_);
         }
     }
 

--- a/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
+++ b/promises-jvm/src/test/java/com/onehilltech/promises/PromiseTest.java
@@ -26,9 +26,7 @@ public class PromiseTest {
     @Test
     public void testSynchronousGetValueSuccess() {
         int expected = 123;
-        Promise<Integer> promise = new Promise < > (settlement -> {
-            settlement.resolve(expected);
-        });
+        Promise<Integer> promise = Promise.resolve(123);
         try {
             int value = promise.getValue();
             Assert.assertEquals(expected, value);
@@ -40,9 +38,7 @@ public class PromiseTest {
     @Test
     public void testSynchronousGetValueFail() {
         String expected = "getValue should throw an exception";
-        Promise<Integer> promise = new Promise < > (settlement -> {
-            settlement.reject(new Exception(expected));
-        });
+        Promise<Integer> promise = Promise.reject(new Exception(expected));
         try {
             int value = promise.getValue();
             Assert.fail();
@@ -55,16 +51,16 @@ public class PromiseTest {
     public void testAlwaysSuccess() throws Exception {
         synchronized (this.lock_) {
             Promise<Integer> p = Promise.resolve(7);
-
-            p.always(() -> {
-                synchronized (lock_) {
-                    isComplete_ = true;
-                    lock_.notify();
+            p.always(new OnAlways<Integer>() {
+                @Override
+                public void OnAlways() {
+                    synchronized (lock_) {
+                        isComplete_ = true;
+                        lock_.notify();
+                    }
                 }
             });
-
             this.lock_.wait(5000);
-
             Assert.assertTrue(this.isComplete_);
         }
     }
@@ -74,10 +70,13 @@ public class PromiseTest {
         synchronized (this.lock_) {
             Promise<Integer> p = Promise.resolve(7);
 
-            p.always(() -> {
-                synchronized (lock_) {
-                    isComplete_ = true;
-                    lock_.notify();
+            p.always(new OnAlways<Integer>() {
+                @Override
+                public void OnAlways() {
+                    synchronized (lock_) {
+                        isComplete_ = true;
+                        lock_.notify();
+                    }
                 }
             });
 


### PR DESCRIPTION
Hi there,

Thank you for this simple promise library. I've taken the liberty to add two calls I was missing during usage of this library. I've tried to make minimal changes:

- getValue allows the user to get a value of the promise. This is helpful in use cases where you'd like to wait until a promise is either rejected or resolved and get the value.
- always allows the user to set a callback for when the promise is either rejected or resolved.

I hope this helps. Let me know if there are any changes I should make.