### PR TITLE
Better gradle dependency declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ Promise library for JVM and Android
 
 ### Gradle
 
-```groovy
-buildscript {
-  repositories {
-    maven { url "https://jitpack.io" }
-  }
+```gradle
+repositories {
+    maven { url "https://jitpack.io" 
+      // https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering
+      content {
+          // filter only artifacts with group "io.emeraldpay.polkaj"
+          includeGroup "com.onehilltech.promises"
+      }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
1) use filtering for repository, as gradle may try to download all other dependency from https://jitpack.io

2) remove `buildscript{` as that is actually outdated, and was used for plugins, no dependencies
See https://docs.gradle.org/current/userguide/declaring_repositories.html